### PR TITLE
Netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,5 @@
+ # Redirecionar envios para o endereço de e-mail usando o recurso de tratamento de formulários do Netlify.
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
Integration with Netlify – The contact form is now configured to redirect submissions to the email address mercuriolocacoes@gmail.com using Netlify's form handling feature.